### PR TITLE
Update WH40k for Planetfall Cycle

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,6 @@ Features:
   Netrunner
   AGoT 2.0
   Warhammer 40k Conquest (up to Planetfall Cycle: Decree of Ruin)
-  Doomtown Reloaded
 
 NOTE: "Official" OCTGN image packs will usually contain higher quality scans. If an official pack is
 available, consider installing it first, and run octgnNetImages after. Any pre-existing images will

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Downloads uncensored card images to be used by the application.
 Features:
   Netrunner
   AGoT 2.0
-  Warhammer 40k Conquest
+  Warhammer 40k Conquest (up to Planetfall Cycle: Decree of Ruin)
   Doomtown Reloaded
 
 NOTE: "Official" OCTGN image packs will usually contain higher quality scans. If an official pack is

--- a/README.txt
+++ b/README.txt
@@ -6,6 +6,7 @@ Features:
   Netrunner
   AGoT 2.0
   Warhammer 40k Conquest
+  Doomtown Reloaded
 
 NOTE: "Official" OCTGN image packs will usually contain higher quality scans. If an official pack is
 available, consider installing it first, and run octgnNetImages after. Any pre-existing images will

--- a/games.go
+++ b/games.go
@@ -98,14 +98,14 @@ func doomtownSet(info CardInfo) (setNumber string) {
 	}
 }
 
-// The Warlord Cycle is broken into subsets in the image database, while the GameDatabase definition just has them
-// all defined as a single set. Break them down by card number.
+// Some cycles are  broken into subsets in the image database, while the GameDatabase definition
+// just has them all defined as a single set. Break them down by card number.
 func wh40kSubset(info CardInfo) (subset string) {
 	cardNum, _ := strconv.Atoi(info.Number)
 
 	switch {
 	default:
-		return "01"
+		return "unknown"
 	case info.SetID == "35c6df08-5a89-47bb-b8f3-624bcd8d9d43": // Core Set
 		return "01"
 	case info.SetID == "9a38f053-1b57-46f5-8578-39e4d1bb45d9": // Warlord Cycle
@@ -123,7 +123,13 @@ func wh40kSubset(info CardInfo) (subset string) {
 		return "07"
 	case info.SetID == "8a92e0bc-0c4d-484d-9177-42cd9ebba406": // The Great Devouerer
 		return "08"
+	case info.SetID == "af362a3a-4f60-4050-801e-0a7bb8dd58bf": // Planetfall Cycle
+		if cardNum < 25 {
+			return "09"
+		}
 	}
+
+	return "unknown"
 
 }
 

--- a/games.go
+++ b/games.go
@@ -22,6 +22,7 @@ var gameList = []Game{
 	netrunner,
 	thrones,
 	wh40kconquest,
+	doomtown,
 }
 
 var netrunner = Game{
@@ -56,6 +57,45 @@ var wh40kconquest = Game{
 	ComposeURL: func(info CardInfo) string {
 		return fmt.Sprintf("http://s3.amazonaws.com/LCG/40kconquest/med_WHK%s_%s.jpg", wh40kSubset(info), info.Number)
 	},
+}
+
+var doomtown = Game{
+	Name:        "Doomtown Reloaded",
+	ID:          "b440d120-025a-4fbe-9f8d-3873acacb37b",
+	IgnoreSets:  []string{"49f27cd8-8398-4165-b7e7-f93497f0c54b"},
+	IgnoreCards: []string{},
+	ComposeURL: func(info CardInfo) string {
+		return fmt.Sprintf("http://dtdb.co/web/bundles/dtdbcards/images/cards/en/%s%03s.jpg", doomtownSet(info), info.Number)
+	},
+}
+
+func doomtownSet(info CardInfo) (setNumber string) {
+	switch {
+	default:
+		return "unknown"
+	case info.Set == "Core Set":
+		return "01"
+	case info.Set == "New Town, New Rules":
+		return "02"
+	case info.Set == "Double Dealin'":
+		return "03"
+	case info.Set == "Election Day Slaughter":
+		return "04"
+	case info.Set == "Faith and Fear":
+		return "05"
+	case info.Set == "Frontier Justice":
+		return "06"
+	case info.Set == "No Turning Back":
+		return "07"
+	case info.Set == "Nightmare at Noon":
+		return "08"
+	case info.Set == "Immovable Object, Unstoppable Force":
+		return "09"
+	case info.Set == "The Light Shineth":
+		return "10"
+	case info.Set == "Dirty Deeds":
+		return "11"
+	}
 }
 
 // The Warlord Cycle is broken into subsets in the image database, while the GameDatabase definition just has them

--- a/games.go
+++ b/games.go
@@ -22,7 +22,6 @@ var gameList = []Game{
 	netrunner,
 	thrones,
 	wh40kconquest,
-	doomtown,
 }
 
 var netrunner = Game{
@@ -57,45 +56,6 @@ var wh40kconquest = Game{
 	ComposeURL: func(info CardInfo) string {
 		return fmt.Sprintf("http://s3.amazonaws.com/LCG/40kconquest/med_WHK%s_%s.jpg", wh40kSubset(info), info.Number)
 	},
-}
-
-var doomtown = Game{
-	Name:        "Doomtown Reloaded",
-	ID:          "b440d120-025a-4fbe-9f8d-3873acacb37b",
-	IgnoreSets:  []string{"49f27cd8-8398-4165-b7e7-f93497f0c54b"},
-	IgnoreCards: []string{},
-	ComposeURL: func(info CardInfo) string {
-		return fmt.Sprintf("http://dtdb.co/web/bundles/dtdbcards/images/cards/en/%s%03s.jpg", doomtownSet(info), info.Number)
-	},
-}
-
-func doomtownSet(info CardInfo) (setNumber string) {
-	switch {
-	default:
-		return "unknown"
-	case info.Set == "Core Set":
-		return "01"
-	case info.Set == "New Town, New Rules":
-		return "02"
-	case info.Set == "Double Dealin'":
-		return "03"
-	case info.Set == "Election Day Slaughter":
-		return "04"
-	case info.Set == "Faith and Fear":
-		return "05"
-	case info.Set == "Frontier Justice":
-		return "06"
-	case info.Set == "No Turning Back":
-		return "07"
-	case info.Set == "Nightmare at Noon":
-		return "08"
-	case info.Set == "Immovable Object, Unstoppable Force":
-		return "09"
-	case info.Set == "The Light Shineth":
-		return "10"
-	case info.Set == "Dirty Deeds":
-		return "11"
-	}
 }
 
 // Some cycles are  broken into subsets in the image database, while the GameDatabase definition


### PR DESCRIPTION
The OCTGN plugin author updated this weekend with a new release that supports the first pack of the Planetfall Cycle. 
